### PR TITLE
feat(reports): KPI, schedule, and CSV export endpoints for admin

### DIFF
--- a/backend/prisma/migrations/20250913175546_add_health_models/migration.sql
+++ b/backend/prisma/migrations/20250913175546_add_health_models/migration.sql
@@ -1,0 +1,53 @@
+-- CreateTable
+CREATE TABLE "public"."Vaccination" (
+    "id" TEXT NOT NULL,
+    "petId" TEXT NOT NULL,
+    "vetId" TEXT,
+    "vaccineName" TEXT NOT NULL,
+    "givenDate" TIMESTAMP(3) NOT NULL,
+    "nextDueDate" TIMESTAMP(3),
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Vaccination_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Medication" (
+    "id" TEXT NOT NULL,
+    "petId" TEXT NOT NULL,
+    "prescribedById" TEXT,
+    "name" TEXT NOT NULL,
+    "dosage" TEXT,
+    "frequency" TEXT,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3),
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Medication_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Vaccination_petId_idx" ON "public"."Vaccination"("petId");
+
+-- CreateIndex
+CREATE INDEX "Vaccination_givenDate_idx" ON "public"."Vaccination"("givenDate");
+
+-- CreateIndex
+CREATE INDEX "Medication_petId_idx" ON "public"."Medication"("petId");
+
+-- CreateIndex
+CREATE INDEX "Medication_startDate_idx" ON "public"."Medication"("startDate");
+
+-- AddForeignKey
+ALTER TABLE "public"."Vaccination" ADD CONSTRAINT "Vaccination_petId_fkey" FOREIGN KEY ("petId") REFERENCES "public"."Pet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Vaccination" ADD CONSTRAINT "Vaccination_vetId_fkey" FOREIGN KEY ("vetId") REFERENCES "public"."Vet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Medication" ADD CONSTRAINT "Medication_petId_fkey" FOREIGN KEY ("petId") REFERENCES "public"."Pet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Medication" ADD CONSTRAINT "Medication_prescribedById_fkey" FOREIGN KEY ("prescribedById") REFERENCES "public"."Vet"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -64,6 +64,8 @@ model Pet {
   updatedAt DateTime  @updatedAt
 
   appointments Appointment[]
+  vaccinations Vaccination[]
+  medications  Medication[]
 
   @@index([ownerId])
 }
@@ -80,6 +82,8 @@ model Vet {
 
   availability Availability[]
   appointments Appointment[]
+  vaccinations Vaccination[]
+  medications  Medication[]
 
   @@index([name])
 }
@@ -132,4 +136,44 @@ model Payment {
   status        PaymentStatus @default(PENDING)
   reference     String?
   createdAt     DateTime      @default(now())
+}
+
+model Vaccination {
+  id    String @id @default(cuid())
+  petId String
+  pet   Pet    @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  vetId String?
+  vet   Vet?    @relation(fields: [vetId], references: [id], onDelete: SetNull)
+
+  vaccineName String
+  givenDate   DateTime
+  nextDueDate DateTime?
+  notes       String?
+
+  createdAt DateTime @default(now())
+
+  @@index([petId])
+  @@index([givenDate])
+}
+
+model Medication {
+  id    String @id @default(cuid())
+  petId String
+  pet   Pet    @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  prescribedById String?
+  prescribedBy   Vet?    @relation(fields: [prescribedById], references: [id], onDelete: SetNull)
+
+  name      String
+  dosage    String?
+  frequency String?
+  startDate DateTime
+  endDate   DateTime?
+  notes     String?
+
+  createdAt DateTime @default(now())
+
+  @@index([petId])
+  @@index([startDate])
 }

--- a/backend/src/health/routes.ts
+++ b/backend/src/health/routes.ts
@@ -1,0 +1,186 @@
+import { Router } from "express";
+import { prisma } from "../lib/prisma";
+import { requireAuth, requireRole, AuthedRequest } from "../middleware/auth";
+import { z } from "zod";
+
+const router = Router();
+const msg = (e: unknown) => (e instanceof Error ? e.message : "unexpected error");
+
+// ---------- Zod Schemas ----------
+const VaccinationCreate = z.object({
+  petId: z.string().min(1),
+  vaccineName: z.string().min(1),
+  givenDate: z.coerce.date(),
+  nextDueDate: z.coerce.date().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+const MedicationCreate = z.object({
+  petId: z.string().min(1),
+  name: z.string().min(1),
+  dosage: z.string().optional(),
+  frequency: z.string().optional(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+// ---------- Helpers ----------
+async function assertPetOwnershipOrElevated(req: AuthedRequest, petId: string) {
+  if (req.user!.role === "ADMIN" || req.user!.role === "VET") return;
+  const owned = await prisma.pet.findFirst({
+    where: { id: petId, ownerId: req.user!.id },
+    select: { id: true },
+  });
+  if (!owned) throw new Error("Pet not found or not owned by user");
+}
+
+// ---------- Vaccinations ----------
+
+// VET/ADMIN create vaccination (owners cannot add per spec)
+router.post("/vaccinations", requireAuth, async (req: AuthedRequest, res) => {
+  const parsed = VaccinationCreate.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ ok: false, error: parsed.error.issues });
+
+  try {
+    if (req.user!.role === "OWNER") {
+      return res.status(403).json({ ok: false, error: "Only VET/ADMIN can add vaccinations" });
+    }
+    await assertPetOwnershipOrElevated(req, parsed.data.petId);
+
+    const created = await prisma.vaccination.create({
+      data: {
+        petId: parsed.data.petId,
+        vetId: req.user!.role === "VET" ? req.user!.id : null,
+        vaccineName: parsed.data.vaccineName,
+        givenDate: parsed.data.givenDate,
+        nextDueDate: parsed.data.nextDueDate,
+        notes: parsed.data.notes,
+      },
+      select: {
+        id: true,
+        vaccineName: true,
+        givenDate: true,
+        nextDueDate: true,
+        notes: true,
+        pet: { select: { id: true, name: true } },
+      },
+    });
+
+    res.status(201).json({ ok: true, vaccination: created });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: msg(e) });
+  }
+});
+
+// list vaccinations by pet
+router.get("/vaccinations", requireAuth, async (req: AuthedRequest, res) => {
+  const petId = String(req.query.petId || "");
+  if (!petId) return res.status(400).json({ ok: false, error: "petId is required" });
+
+  try {
+    await assertPetOwnershipOrElevated(req, petId);
+
+    const list = await prisma.vaccination.findMany({
+      where: { petId },
+      orderBy: { givenDate: "desc" },
+      select: {
+        id: true, vaccineName: true, givenDate: true, nextDueDate: true, notes: true,
+      },
+    });
+
+    res.json({ ok: true, vaccinations: list });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: msg(e) });
+  }
+});
+
+// ---------- Medications ----------
+
+// OWNER or VET/ADMIN can add medication
+router.post("/medications", requireAuth, async (req: AuthedRequest, res) => {
+  const parsed = MedicationCreate.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ ok: false, error: parsed.error.issues });
+
+  try {
+    await assertPetOwnershipOrElevated(req, parsed.data.petId);
+
+    const created = await prisma.medication.create({
+      data: {
+        petId: parsed.data.petId,
+        prescribedById: req.user!.role === "VET" ? req.user!.id : null,
+        name: parsed.data.name,
+        dosage: parsed.data.dosage,
+        frequency: parsed.data.frequency,
+        startDate: parsed.data.startDate,
+        endDate: parsed.data.endDate,
+        notes: parsed.data.notes,
+      },
+      select: {
+        id: true, name: true, dosage: true, frequency: true,
+        startDate: true, endDate: true, notes: true,
+        pet: { select: { id: true, name: true } },
+      },
+    });
+
+    res.status(201).json({ ok: true, medication: created });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: msg(e) });
+  }
+});
+
+// list medications by pet
+router.get("/medications", requireAuth, async (req: AuthedRequest, res) => {
+  const petId = String(req.query.petId || "");
+  if (!petId) return res.status(400).json({ ok: false, error: "petId is required" });
+
+  try {
+    await assertPetOwnershipOrElevated(req, petId);
+
+    const list = await prisma.medication.findMany({
+      where: { petId },
+      orderBy: [{ startDate: "desc" }],
+      select: {
+        id: true, name: true, dosage: true, frequency: true,
+        startDate: true, endDate: true, notes: true,
+      },
+    });
+
+    res.json({ ok: true, medications: list });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: msg(e) });
+  }
+});
+
+// ---------- Combined Pet Health timeline (optional) ----------
+router.get("/timeline/:petId", requireAuth, async (req: AuthedRequest, res) => {
+  const petId = req.params.petId;
+
+  try {
+    await assertPetOwnershipOrElevated(req, petId);
+
+    const [vaccs, meds] = await Promise.all([
+      prisma.vaccination.findMany({
+        where: { petId },
+        select: { id: true, vaccineName: true, givenDate: true, nextDueDate: true, notes: true },
+        orderBy: { givenDate: "desc" },
+      }),
+      prisma.medication.findMany({
+        where: { petId },
+        select: { id: true, name: true, startDate: true, endDate: true, dosage: true, frequency: true, notes: true },
+        orderBy: { startDate: "desc" },
+      }),
+    ]);
+
+    const timeline = [
+      ...vaccs.map(v => ({ type: "VACCINATION", when: v.givenDate, data: v })),
+      ...meds.map(m => ({ type: "MEDICATION", when: m.startDate, data: m })),
+    ].sort((a, b) => new Date(b.when).getTime() - new Date(a.when).getTime());
+
+    res.json({ ok: true, timeline });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: msg(e) });
+  }
+});
+
+export default router;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,42 +12,21 @@ import vetRoutes from './vet/routes';
 import apptRoutes from './appt/routes';
 import paymentRoutes from './payments/routes';
 import healthRoutes from './health/routes';
+import reportsRoutes from './reports/routes'; // <- NEW
 
-// -----------------------------
-// Create app FIRST
 // -----------------------------
 const app = express();
-
-// Middleware
 app.use(cors());
 app.use(express.json());
 
-// ENV
 const PORT = Number(process.env.PORT || 4000);
 const DATABASE_URL = process.env.DATABASE_URL as string;
-
-// PG pool (for health check)
 const pool = new Pool({ connectionString: DATABASE_URL });
 
-// -----------------------------
-// Health / root routes (public)
-// -----------------------------
-app.get('/', (_req, res) => {
-  res.send('VetCare+ API is running');
-});
-
-app.get('/health', (_req, res) => {
-  res.status(200).json({
-    ok: true,
-    uptime: process.uptime(),
-    timestamp: new Date().toISOString(),
-  });
-});
-
-app.get('/ping', (_req, res) => {
-  res.json({ ok: true, msg: 'VetCare+ API up' });
-});
-
+// Health
+app.get('/', (_req, res) => res.send('VetCare+ API is running'));
+app.get('/health', (_req, res) => res.status(200).json({ ok: true, uptime: process.uptime(), timestamp: new Date().toISOString() }));
+app.get('/ping', (_req, res) => res.json({ ok: true, msg: 'VetCare+ API up' }));
 app.get('/health/db', async (_req, res) => {
   try {
     const r = await pool.query('SELECT 1 as ok');
@@ -58,18 +37,15 @@ app.get('/health/db', async (_req, res) => {
   }
 });
 
-// -----------------------------
 // Feature routes
-// -----------------------------
 app.use('/auth', authRoutes);
 app.use('/pets', petRoutes);
 app.use('/vets', vetRoutes);
 app.use('/appointments', apptRoutes);
 app.use('/payments', paymentRoutes);
 app.use('/pet-health', healthRoutes);
-// -----------------------------
-// Start & graceful shutdown
-// -----------------------------
+app.use('/reports', reportsRoutes); // <- NEW
+
 app.listen(PORT, () => {
   console.log(`API listening on http://localhost:${PORT}`);
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import petRoutes from './pet/routes';
 import vetRoutes from './vet/routes';
 import apptRoutes from './appt/routes';
 import paymentRoutes from './payments/routes';
+import healthRoutes from './health/routes';
 
 // -----------------------------
 // Create app FIRST
@@ -65,7 +66,7 @@ app.use('/pets', petRoutes);
 app.use('/vets', vetRoutes);
 app.use('/appointments', apptRoutes);
 app.use('/payments', paymentRoutes);
-
+app.use('/pet-health', healthRoutes);
 // -----------------------------
 // Start & graceful shutdown
 // -----------------------------

--- a/backend/src/reports/routes.ts
+++ b/backend/src/reports/routes.ts
@@ -1,0 +1,177 @@
+import { Router } from "express";
+import { prisma } from "../lib/prisma";
+import { requireAuth, requireRole } from "../middleware/auth";
+import { z } from "zod";
+
+const router = Router();
+const err = (e: unknown) => (e instanceof Error ? e.message : "unexpected error");
+
+// ---------- Zod schemas ----------
+const RangeSchema = z.object({
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
+});
+
+const DaySchema = z.object({
+  date: z.coerce.date(),
+  vetId: z.string().optional(),
+});
+
+// ---------- /reports/kpi?from=&to= ----------
+router.get("/kpi", requireAuth, requireRole("ADMIN"), async (req, res) => {
+  const parsed = RangeSchema.safeParse(req.query);
+  if (!parsed.success) return res.status(400).json({ ok: false, error: parsed.error.issues });
+
+  const { from, to } = parsed.data;
+
+  try {
+    // Appointments within range
+    const whereRange: any = {};
+    if (from || to) {
+      whereRange.dateTime = {
+        gte: from ?? undefined,
+        lte: to ?? undefined,
+      };
+    }
+
+    const [booked, cancelled, payments] = await Promise.all([
+      prisma.appointment.count({ where: { ...whereRange, status: "BOOKED" } }),
+      prisma.appointment.count({ where: { ...whereRange, status: "CANCELLED" } }),
+      prisma.payment.findMany({
+        where: {
+          appointment: { ...(whereRange.dateTime ? { dateTime: whereRange.dateTime } : {}) },
+          status: "SUCCESS",
+        },
+        select: { amountCents: true },
+      }),
+    ]);
+
+    // Upcoming vaccinations (next 30 days)
+    const now = new Date();
+    const soon = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    const upcomingVacc = await prisma.vaccination.count({
+      where: { nextDueDate: { gte: now, lte: soon } },
+    });
+
+    const revenueCents = payments.reduce((sum, p) => sum + p.amountCents, 0);
+
+    res.json({
+      ok: true,
+      kpi: {
+        timeWindow: { from: from ?? null, to: to ?? null },
+        bookings: booked,
+        cancellations: cancelled,
+        upcomingVaccinations30d: upcomingVacc,
+        mockRevenueCents: revenueCents,
+      },
+    });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: err(e) });
+  }
+});
+
+// ---------- /reports/schedule?date=YYYY-MM-DD[&vetId=] ----------
+router.get("/schedule", requireAuth, requireRole("ADMIN"), async (req, res) => {
+  const parsed = DaySchema.safeParse({
+    date: req.query.date,
+    vetId: req.query.vetId,
+  });
+  if (!parsed.success) return res.status(400).json({ ok: false, error: parsed.error.issues });
+
+  const { date, vetId } = parsed.data;
+
+  try {
+    const start = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0));
+    const end = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 23, 59, 59, 999));
+
+    const where: any = { dateTime: { gte: start, lte: end } };
+    if (vetId) where.vetId = vetId;
+
+    const appts = await prisma.appointment.findMany({
+      where,
+      orderBy: { dateTime: "asc" },
+      select: {
+        id: true, status: true, dateTime: true,
+        vet: { select: { id: true, name: true } },
+        pet: { select: { id: true, name: true } },
+        owner: { select: { id: true, email: true, name: true } },
+        payment: { select: { status: true, amountCents: true } },
+      },
+    });
+
+    res.json({ ok: true, schedule: appts });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: err(e) });
+  }
+});
+
+// ---------- /reports/export.csv?from=&to= ----------
+router.get("/export.csv", requireAuth, requireRole("ADMIN"), async (req, res) => {
+  const parsed = RangeSchema.safeParse(req.query);
+  if (!parsed.success) return res.status(400).json({ ok: false, error: parsed.error.issues });
+
+  const { from, to } = parsed.data;
+
+  try {
+    const where: any = {};
+    if (from || to) {
+      where.dateTime = {
+        gte: from ?? undefined,
+        lte: to ?? undefined,
+      };
+    }
+
+    const rows = await prisma.appointment.findMany({
+      where,
+      orderBy: { dateTime: "asc" },
+      select: {
+        id: true,
+        dateTime: true,
+        status: true,
+        vet: { select: { name: true } },
+        pet: { select: { name: true } },
+        owner: { select: { email: true } },
+        payment: { select: { status: true, amountCents: true, reference: true } },
+      },
+    });
+
+    // CSV build
+    const header = [
+      "appointment_id",
+      "date_time_iso",
+      "status",
+      "vet_name",
+      "pet_name",
+      "owner_email",
+      "payment_status",
+      "amount_cents",
+      "payment_ref",
+    ].join(",");
+
+    const lines = rows.map(r =>
+      [
+        r.id,
+        r.dateTime.toISOString(),
+        r.status,
+        r.vet?.name ?? "",
+        r.pet?.name ?? "",
+        r.owner?.email ?? "",
+        r.payment?.status ?? "",
+        r.payment?.amountCents ?? "",
+        r.payment?.reference ?? "",
+      ]
+        .map(v => String(v).replace(/"/g, '""'))
+        .map(v => (v.includes(",") ? `"${v}"` : v))
+        .join(",")
+    );
+
+    const csv = [header, ...lines].join("\n");
+    res.setHeader("Content-Type", "text/csv");
+    res.setHeader("Content-Disposition", `attachment; filename="appointments_export.csv"`);
+    res.send(csv);
+  } catch (e) {
+    res.status(500).json({ ok: false, error: err(e) });
+  }
+});
+
+export default router;


### PR DESCRIPTION
# Summary
Adds reports module for VetCare+:
- KPI (bookings, cancellations, upcoming vaccinations in 30d, mock revenue)
- Daily schedule per clinic or per vet
- CSV export for appointments (for test artifacts/reporting)

# Endpoints
- GET /reports/kpi?from=&to=  (ADMIN)
- GET /reports/schedule?date=YYYY-MM-DD[&vetId=]  (ADMIN)
- GET /reports/export.csv?from=&to=  (ADMIN)

# Notes
- Designed for Postman/Newman regression + demo reports.
- No schema changes required.

<img width="1406" height="891" alt="schedule" src="https://github.com/user-attachments/assets/ad48280a-54f4-46b4-9f37-57ef6d4deb6c" />
