### PR TITLE
feat(payments): status transitions (complete/fail/refund)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,7 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.11.5",
-        "zod": "^4.1.5"
+        "zod": "^4.1.8"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -2225,9 +2225,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
-      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.11.5",
-    "zod": "^4.1.5"
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -29,6 +29,7 @@ enum PaymentStatus {
   PENDING
   SUCCESS
   FAILED
+  REFUNDED
 }
 
 //////////////////////
@@ -128,16 +129,6 @@ model Appointment {
   @@index([dateTime])
 }
 
-model Payment {
-  id            String        @id @default(cuid())
-  appointmentId String        @unique
-  appointment   Appointment   @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
-  amountCents   Int
-  status        PaymentStatus @default(PENDING)
-  reference     String?
-  createdAt     DateTime      @default(now())
-}
-
 model Vaccination {
   id    String @id @default(cuid())
   petId String
@@ -176,4 +167,21 @@ model Medication {
 
   @@index([petId])
   @@index([startDate])
+}
+
+model Payment {
+  id            String      @id @default(cuid())
+  appointmentId String      @unique
+  appointment   Appointment @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
+
+  // Use smallest currency unit to avoid floating point issues
+  amountCents Int
+  provider    String // "mock", "stripe", etc.
+  reference   String? // external reference if any
+  status      PaymentStatus @default(PENDING)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([appointmentId])
 }

--- a/backend/src/appt/routes.ts
+++ b/backend/src/appt/routes.ts
@@ -83,11 +83,16 @@ router.post("/", requireAuth, async (req: AuthedRequest, res) => {
         },
       });
 
-      // mock PENDING payment (flat amount)
-      await tx.payment.create({
-        data: { appointmentId: created.id, amountCents: 3500, status: "PENDING" },
-      });
-
+      // mock PENDING payment (flat amount)  
+         await tx.payment.create({
+         data: {
+    appointmentId: created.id,
+    amountCents: 3500,
+    status: "PENDING",
+    // provider missing here before -> add it:
+    provider: "mock",
+  },
+});
       return created;
     });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,8 +12,8 @@ import vetRoutes from './vet/routes';
 import apptRoutes from './appt/routes';
 import paymentRoutes from './payments/routes';
 import healthRoutes from './health/routes';
-import reportsRoutes from './reports/routes'; // <- NEW
-
+import reportsRoutes from './reports/routes'; 
+import payRoutes from './pay/routes';
 // -----------------------------
 const app = express();
 app.use(cors());
@@ -44,8 +44,8 @@ app.use('/vets', vetRoutes);
 app.use('/appointments', apptRoutes);
 app.use('/payments', paymentRoutes);
 app.use('/pet-health', healthRoutes);
-app.use('/reports', reportsRoutes); // <- NEW
-
+app.use('/reports', reportsRoutes); 
+app.use('/payments', payRoutes);
 app.listen(PORT, () => {
   console.log(`API listening on http://localhost:${PORT}`);
 });

--- a/backend/src/pay/routes.ts
+++ b/backend/src/pay/routes.ts
@@ -1,0 +1,171 @@
+import { Router } from "express";
+import { prisma } from "../lib/prisma";
+import { requireAuth } from "../middleware/auth";
+
+const router = Router();
+
+/**
+ * Helpers
+ */
+function isAdmin(user: any) { return user?.role === "ADMIN"; }
+
+// Owner of appointment or admin can act
+async function canActOnAppointment(userId: string, apptId: string, admin: boolean) {
+  if (admin) return true;
+  const appt = await prisma.appointment.findUnique({ where: { id: apptId }, select: { ownerId: true }});
+  return appt?.ownerId === userId;
+}
+
+/**
+ * POST /payments
+ * Create a payment for an appointment that does NOT already have one.
+ * Enforces one Payment per Appointment (appointmentId is unique).
+ */
+router.post("/", requireAuth, async (req, res) => {
+  try {
+    const user = (req as any).user;
+    const { appointmentId, amountCents, provider = "mock" } = req.body as {
+      appointmentId: string;
+      amountCents: number;
+      provider?: string;
+    };
+
+    if (!appointmentId || !amountCents) {
+      return res.status(400).json({ ok: false, error: "appointmentId and amountCents are required" });
+    }
+
+    const allowed = await canActOnAppointment(user.id, appointmentId, isAdmin(user));
+    if (!allowed) return res.status(403).json({ ok: false, error: "Forbidden" });
+
+    // ensure appointment exists and doesn’t already have payment
+    const existing = await prisma.payment.findUnique({ where: { appointmentId } });
+    if (existing) return res.status(409).json({ ok: false, error: "Payment already exists for this appointment" });
+
+    const payment = await prisma.payment.create({
+      data: {
+        appointmentId,
+        amountCents,
+        provider,
+        status: "PENDING",
+      },
+      select: {
+        id: true, amountCents: true, provider: true, status: true, createdAt: true,
+        appointment: {
+          select: {
+            id: true, dateTime: true, status: true,
+            pet: { select: { id: true, name: true }},
+            vet: { select: { id: true, name: true }},
+            ownerId: true
+          }
+        }
+      }
+    });
+
+    return res.status(201).json({ ok: true, payment });
+  } catch (err: any) {
+    return res.status(400).json({ ok: false, error: err?.message || "create payment error" });
+  }
+});
+
+/**
+ * GET /payments
+ * Admin: all payments; Owner: only their payments.
+ */
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const user = (req as any).user;
+    const whereFilter = isAdmin(user) ? {} : { appointment: { ownerId: user.id } };
+
+    const payments = await prisma.payment.findMany({
+      where: whereFilter,
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true, amountCents: true, provider: true, reference: true, status: true, createdAt: true,
+        appointment: {
+          select: {
+            id: true, dateTime: true, status: true,
+            pet: { select: { id: true, name: true }},
+            vet: { select: { id: true, name: true }},
+            ownerId: true
+          }
+        }
+      }
+    });
+
+    return res.json({ ok: true, payments });
+  } catch (err: any) {
+    return res.status(400).json({ ok: false, error: err?.message || "list payments error" });
+  }
+});
+
+/**
+ * POST /payments/:id/complete   -> status: SUCCESS
+ * POST /payments/:id/fail       -> status: FAILED
+ * POST /payments/:id/refund     -> status: REFUNDED (admin only)
+ */
+router.post("/:id/complete", requireAuth, async (req, res) => {
+  try {
+    const user = (req as any).user;
+    const id = req.params.id;
+
+    // Owner of linked appointment or admin
+    const pay = await prisma.payment.findUnique({ where: { id }, select: { appointment: { select: { ownerId: true }}}});
+    if (!pay) return res.status(404).json({ ok: false, error: "Payment not found" });
+    if (!isAdmin(user) && pay.appointment.ownerId !== user.id) {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+
+    const updated = await prisma.payment.update({
+      where: { id },
+      data: { status: "SUCCESS", reference: `MOCK-SUCCESS-${Date.now()}` },
+      select: { id: true, status: true, reference: true }
+    });
+    return res.json({ ok: true, payment: updated });
+  } catch (err: any) {
+    return res.status(400).json({ ok: false, error: err?.message || "complete error" });
+  }
+});
+
+router.post("/:id/fail", requireAuth, async (req, res) => {
+  try {
+    const user = (req as any).user;
+    const id = req.params.id;
+
+    const pay = await prisma.payment.findUnique({ where: { id }, select: { appointment: { select: { ownerId: true }}}});
+    if (!pay) return res.status(404).json({ ok: false, error: "Payment not found" });
+    if (!isAdmin(user) && pay.appointment.ownerId !== user.id) {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
+
+    const updated = await prisma.payment.update({
+      where: { id },
+      data: { status: "FAILED", reference: `MOCK-FAILED-${Date.now()}` },
+      select: { id: true, status: true, reference: true }
+    });
+    return res.json({ ok: true, payment: updated });
+  } catch (err: any) {
+    return res.status(400).json({ ok: false, error: err?.message || "fail error" });
+  }
+});
+
+router.post("/:id/refund", requireAuth, async (req, res) => {
+  try {
+    const user = (req as any).user;
+    if (!isAdmin(user)) return res.status(403).json({ ok: false, error: "Admin only" });
+
+    const id = req.params.id;
+    const found = await prisma.payment.findUnique({ where: { id }, select: { id: true }});
+    if (!found) return res.status(404).json({ ok: false, error: "Payment not found" });
+
+    const updated = await prisma.payment.update({
+      where: { id },
+      data: { status: "REFUNDED", reference: `MOCK-REFUND-${Date.now()}` },
+      select: { id: true, status: true, reference: true }
+    });
+    return res.json({ ok: true, payment: updated });
+  } catch (err: any) {
+    return res.status(400).json({ ok: false, error: err?.message || "refund error" });
+  }
+});
+
+export default router;

--- a/backend/src/pay/types.ts
+++ b/backend/src/pay/types.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const PaymentCreateSchema = z.object({
+  appointmentId: z.string().min(1),
+  // use cents/paise to avoid floating issues (e.g., 5000 = ₹50.00 / $50.00)
+  amountCents: z.number().int().positive(),
+  provider: z.string().min(1).default('mock'),
+});
+
+export type PaymentCreateInput = z.infer<typeof PaymentCreateSchema>;


### PR DESCRIPTION
New POST /payments (owner/admin) — creates PENDING payment if appointment has none.

Status endpoints:

POST /payments/:id/complete → SUCCESS

POST /payments/:id/fail → FAILED

POST /payments/:id/refund (ADMIN) → REFUNDED

Owner/admin guards; owners can only act on their own appointments.

/payments list joins appointment/pet/vet.

Keeps one payment per appointment (clean audit for reports).

Schema/compat

Payment includes provider, amountCents, status, reference.

No breaking changes beyond fields already migrated.